### PR TITLE
Map service principals to existing by name

### DIFF
--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -442,6 +442,7 @@ def build_client_config(profile, url, token, args):
     config['num_parallel'] = args.num_parallel
     config['retry_total'] = args.retry_total
     config['retry_backoff'] = args.retry_backoff
+    config['map_service_principals_by_name'] = args.map_service_principals_by_name
     return config
 
 
@@ -478,6 +479,10 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--cluster-name', action='store', required=False,
                         help='Cluster name to export the metastore to a specific cluster. Cluster will be started.')
+
+    # User, service principals and group arguments
+    parser.add_argument('--map-service-principals-by-name', action='store_true',
+                        help='Try to map existing service principals by name instead of creating new ones by default. No name duplicates are allowed in origin or destination.')
 
     # Workspace arguments
     parser.add_argument('--notebook-format', type=NotebookFormat,

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -102,7 +102,7 @@ class ServicePrincipalImportTask(AbstractTask):
 
     def run(self):
         scim_c = ScimClient(self.client_config, self.checkpoint_service)
-        scim_c.import_all_service_principals(num_parallel=self.client_config["num_parallel"])
+        scim_c.import_all_service_principals(map_existing_by_name=self.client_config["map_service_principals_by_name"], num_parallel=self.client_config["num_parallel"])
 
 
 class GroupImportTask(AbstractTask):


### PR DESCRIPTION
If the target workspace has terraformed resource such as service principals, the migration tool should try to use those instead of creating new ones. This situation doesn't happen with users, since when they're created with an already existing email Databricks API doesn't create new, extra users.

This PR introduces an opt-in flag in the migration pipeline entry point that will search for existing service principals by displayName and map them.
Enabling it will make the app double check there are no displayName duplicates in origin or destination

Note: this PR starts from https://github.com/OSS-Nextail/databricks-migrate/pull/3, will rebase when needed 