### PR TITLE
Map service principal job acls

### DIFF
--- a/dbclient/ScimClient.py
+++ b/dbclient/ScimClient.py
@@ -210,19 +210,21 @@ class ScimClient(dbclient):
             return user_id_dict
         return None
 
-    def get_service_principal_id_mapping(self, sp_mapping_logfile='service_principals_id_mapping.log'):
+    @staticmethod
+    def get_service_principal_id_mapping(export_dir, sp_mapping_logfile='service_principals_id_mapping.log'):
         # return a dict of the former service principal app mapping to the app id in the new env
         sp_app_id_dict = {}
-        with open(self.get_export_dir() + sp_mapping_logfile, 'r') as fp:
+        with open(export_dir + sp_mapping_logfile, 'r') as fp:
             for sp in fp:
                 sp = json.loads(sp)
                 sp_app_id_dict[sp['exported_id']] = sp['current_id']
         return sp_app_id_dict
 
-    def get_service_principal_app_id_mapping(self, sp_mapping_logfile='service_principals_id_mapping.log'):
+    @staticmethod
+    def get_service_principal_app_id_mapping(export_dir, sp_mapping_logfile='service_principals_id_mapping.log'):
         # return a dict of the former service principal app mapping to the app id in the new env
         sp_app_id_dict = {}
-        with open(self.get_export_dir() + sp_mapping_logfile, 'r') as fp:
+        with open(export_dir + sp_mapping_logfile, 'r') as fp:
             for sp in fp:
                 sp = json.loads(sp)
                 sp_app_id_dict[sp['exported_app_id']] = sp['current_app_id']
@@ -527,7 +529,7 @@ class ScimClient(dbclient):
         # dict of { group_name : group_id }
         groups = self.listdir(group_dir)
         current_group_ids = self.get_current_group_ids()
-        current_service_principal_ids = self.get_service_principal_id_mapping()
+        current_service_principal_ids = self.get_service_principal_id_mapping(self.get_export_dir())
         # dict of { old_user_id : email }
         old_user_emails = self.get_old_user_emails()
         for group_name in groups:
@@ -689,7 +691,7 @@ class ScimClient(dbclient):
         sp_error_logger = logging_utils.get_error_logger(
             wmconstants.WM_IMPORT, wmconstants.SERVICE_PRINCIPAL_OBJECT, self.get_export_dir())
         self.import_service_principals(sp_log, sp_error_logger, checkpoint_sp_set, map_existing_by_name, num_parallel)
-        current_sp_ids = self.get_service_principal_id_mapping()
+        current_sp_ids = self.get_service_principal_id_mapping(self.get_export_dir())
         self.log_failed_service_principals(current_sp_ids, sp_log, sp_error_logger)
 
         # assign the service principals to IAM roles if on AWS

--- a/dbclient/ScimClient.py
+++ b/dbclient/ScimClient.py
@@ -230,6 +230,17 @@ class ScimClient(dbclient):
                 sp_app_id_dict[sp['exported_app_id']] = sp['current_app_id']
         return sp_app_id_dict
 
+    @staticmethod
+    def map_service_principals_in_acl(acl, service_principal_app_id_mapping, error_logger):
+        for i, acl_entry in enumerate(acl):
+            app_id = acl_entry.get('service_principal_name', None)
+            if app_id:
+                acl_entry['service_principal_name'] = service_principal_app_id_mapping.get(app_id, None)
+                if not acl_entry['service_principal_name']:
+                    error_logger.error(f"Service principal {app_id} not found in service principal mapping (not migrated?). Skipping ACL import.")
+                    del acl[i]
+        return acl
+
     def get_current_service_principals_by_name(self):
         # return a dict of the current service principal app mapping to the id and app id in the new env
         # raises an exception if there is a duplicate name

--- a/dbclient/__init__.py
+++ b/dbclient/__init__.py
@@ -1,9 +1,9 @@
 import json
 from .dbclient import dbclient
 from .ClustersClient import ClustersClient
+from .ScimClient import ScimClient
 from .JobsClient import JobsClient
 from .DbfsClient import DbfsClient
-from .ScimClient import ScimClient
 from .LibraryClient import LibraryClient
 from .WorkspaceClient import WorkspaceClient
 from .HiveClient import HiveClient


### PR DESCRIPTION
Fixes the issue where Job ACLs would fail on migration if they contained some service principal. It uses the mapping produced during service principal import